### PR TITLE
deps: Use caret ^ semver for nan

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "repository": "https://github.com/pulsar-edit/fuzzy-native",
   "license": "MIT",
   "dependencies": {
-    "nan": "2.17.0"
+    "nan": "^2.17.0"
   },
   "devDependencies": {
     "jasmine-node": "^1.14.5",


### PR DESCRIPTION
### Change:

Adds `^` (caret semver) when specifying the `nan` dependency.

### Motivation:

Allows later upgrades within the same major versions of `nan`, _without_ coming back to modify this package's `package.json` file _and then_ bumping this package's version in any/all consumers of this package.

### Context:

This is a follow-up to #1, which removed the caret `^` semver in specifying the `nan` dependency in `package.json`.

### Rationale:

I don't think it's a good trade-off to pin an exact version of `nan`.

I've never had a problem updating to a newer version of `nan` (no point in pinning an exact version), but with new versions of NodeJS and Electron coming out all the time, bumping `nan` in our direct/indirect dependencies is frequently quite helpful (lots of reasons to upgrade frequently, caret `^` semver comes in handy for this).

Dealing with exact pinned version is much more laborious than just refreshing your lockfile, so caret `^` semver is the way to go for `nan`, IMO.

Also helps optimize the deduplication of different `nan` versions, not that `nan` is a very heavy dependency if I recall correctly. Wider/more-permissive semver ranges for `nan` allow one version of `nan` to satisfy the requirements of more packages.