### PR TITLE
Set up CI publishing pipeline to NPM

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,33 @@
+name: NPM Publish
+
+on:
+  release:
+    types: [created]
+  workflow_dispatch:
+
+env:
+  NODE_VERSION: 16
+  NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - run: npm ci
+      - run: npm test
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          registry-url: https://registry.npmjs.org/
+      - run: npm ci
+      - run: npm publish --access public

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ node_modules
 
 # Local-only
 local
+
+# `clangd` cache files
+.cache

--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,7 @@
 # See the root package.json's "files" for what is included.
 # npm5 ignores empty .npmignore files so add something trivial.
 /node_modules
+.travis.yml
+.last-synced-commit
+.github
+npm-debug.log


### PR DESCRIPTION
Proceeding down [my checklist](https://gist.github.com/savetheclocktower/b3655727786e264d841db5d403a4a771?permalink_comment_id=5450119#gistcomment-5450119), here's the next package to start publishing to NPM.

Copied what was done for `less-cache`; seems like it'll work just fine, but I suppose we'll find out.