### PR TITLE
Explicitly include `cstdint` to make GCC happy

### DIFF
--- a/src/MatcherBase.h
+++ b/src/MatcherBase.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <unordered_map>


### PR DESCRIPTION
Fixes #8.