### PR TITLE
CI: Update `checkout` and `setup-node` actions to v6

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,8 +13,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
       - run: npm ci
@@ -24,8 +24,8 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: https://registry.npmjs.org/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout the latest code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
 
     - name: Setup node
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v6
       with:
         node-version: 16
 


### PR DESCRIPTION
v3 of these actions use Node 16, which is deprecated in GitHub Actions. v4 of these actions use Node 20, which is also deprecated.

Update to the latest versions of each, which currently happens to be v6 for both of them. v6 of these actions use Node 24, which is not yet deprecated :).