### PR TITLE
CI: Update Node, and use matrix with org var to set Node version for `tests` workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 env:
-  NODE_VERSION: 16
+  NODE_VERSION: 20
   NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
 
 jobs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   test:
-    name: Run tests
+    name: Run tests ('${{ matrix.node_version }}')
     if: |
       !startsWith(github.event.pull_request.title, '[skip-ci]') &&
       !startsWith(github.event.pull_request.title, '[skip-package-ci]')

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,9 @@ jobs:
       !startsWith(github.event.pull_request.title, '[skip-ci]') &&
       !startsWith(github.event.pull_request.title, '[skip-package-ci]')
     runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        node_version: [16, '${{ vars.NODE_VERSION }}' ]
     steps:
     - name: Checkout the latest code
       uses: actions/checkout@v3
@@ -18,7 +21,7 @@ jobs:
     - name: Setup node
       uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: '${{ matrix.node_version }}'
 
     - name: Install Python setuptools
       run: python3 -m pip install setuptools

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        node_version: [16, '${{ vars.NODE_VERSION }}' ]
+        node_version: [20, '${{ vars.NODE_VERSION }}' ]
     steps:
     - name: Checkout the latest code
       uses: actions/checkout@v3


### PR DESCRIPTION
### Summary of changes

- Update from Node 16 to Node 20 in `publish.yml` workflow, to loosely match core repo
- Use the org variable to set Node version in `tests.yml` workflow

(Also, for the `tests.yml` workflow job matrix, keep a last known-good Node version in the matrix, so if things were ever to break due to the org variable changing, we have some paper trail of a known-good configuration.)

### Alternative approaches

I left the Node version hard-coded in the publish workflow. (Albeit I did bump it from Node 16 to 20).

I didn't want to add complexity and potential friction to the `publish.yml` workflow. Sanity check testing _could_ run on a matrix of multiple Node versions, I suppose... but that's really what the `tests.yml` workflow is for, IMO. Obviously the actual publish step should only run once.

(Most of the time, it should be the same major Node version in each matrix job anyway, if we're punctual about updating these various repos to sync to core...)

I'm open to adding a test matrix for the `publish.yml` workflow's first half if people really want it.

### Verification

CI passes